### PR TITLE
Stuff that slightly annoyed me :)

### DIFF
--- a/BetterPerspectiveCameraKeys.cs
+++ b/BetterPerspectiveCameraKeys.cs
@@ -89,15 +89,17 @@ namespace BetterPerspective
         protected void Update()
         {
             float num = 0.02f;
-           
+            float distanceMultiplier = _rtsCamera.Distance * 7 / _rtsCamera.MaxDistance + 0.1f;
+            float distanceModifier = Mathf.Sqrt(_rtsCamera.Distance / _rtsCamera.MaxDistance) * 2;
+
                 FastMoveSpeed = MoveSpeedVar * 2;
                 MoveSpeed = MoveSpeedVar;
                 RotateSpeed = RotateSpeedVar;
                 ZoomSpeed = ZoomSpeedVar;
                 TiltSpeed = 90f;
             
-            if (_rtsCamera == null)
-                return; // no camera, bail!
+            if (_rtsCamera == null || UIUtility.isInputFieldFocused())
+                return; // no camera!... or is he typing? who cares, bail!
 
             if (AllowMove && (!_rtsCamera.IsFollowing || MovementBreaksFollow))
             {
@@ -113,14 +115,14 @@ namespace BetterPerspective
                 if (Mathf.Abs(h) > 0.001f)
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(h * speed * num, 0, 0);
+                    _rtsCamera.AddToPosition(h * speed * num * distanceModifier, 0, 0);
                 }
 
                 var v = Input.GetAxisRaw(VerticalInputAxis);
                 if (Mathf.Abs(v) > 0.001f)
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(0, 0, v * speed * num);
+                    _rtsCamera.AddToPosition(0, 0, v * speed * num * distanceModifier);
                 }
 
                 if (hasMovement && _rtsCamera.IsFollowing && MovementBreaksFollow)
@@ -159,18 +161,18 @@ namespace BetterPerspective
                     var zoom = Input.GetAxisRaw(ZoomInputAxis);
                     if (Mathf.Abs(zoom) > 0.001f)
                     {
-                        _rtsCamera.Distance += zoom * ZoomSpeed * num;
+                        _rtsCamera.Distance += zoom * ZoomSpeed * num * distanceMultiplier;
                     }
                 }
                 else
                 {
                     if (Input.GetKey(ZoomOutKey))
                     {
-                        _rtsCamera.Distance += ZoomSpeed * num;
+                        _rtsCamera.Distance += ZoomSpeed * num * distanceMultiplier;
                     }
                     if (Input.GetKey(ZoomInKey))
                     {
-                        _rtsCamera.Distance -= ZoomSpeed * num;
+                        _rtsCamera.Distance -= ZoomSpeed * num * distanceMultiplier;
                     }
                 }
             }

--- a/BetterPerspectiveCameraMouse.cs
+++ b/BetterPerspectiveCameraMouse.cs
@@ -80,8 +80,11 @@ namespace BetterPerspective
         protected void Update()
         {
             float num = 0.02f;
-           
-                MoveSpeed = 20f;
+            float distanceMultiplier = _rtsCamera.Distance * 7 / _rtsCamera.MaxDistance + 0.1f;
+            float distanceModifier = Mathf.Sqrt(_rtsCamera.Distance / _rtsCamera.MaxDistance) * 2;
+
+
+            MoveSpeed = 20f;
                 RotateSpeed = RotateSpeedVar;
                 ZoomSpeed = ZoomSpeedVar;
                 TiltSpeed = TiltSpeedVar;
@@ -95,7 +98,7 @@ namespace BetterPerspective
             {
 
                 var scroll = -Input.GetAxisRaw(ZoomInputAxis);
-                _rtsCamera.Distance -= scroll * ZoomSpeed * num;
+                _rtsCamera.Distance -= scroll * ZoomSpeed * num * distanceMultiplier;
             }
 
             if (Input.GetKey(MouseOrbitButton))
@@ -138,23 +141,23 @@ namespace BetterPerspective
                 if (Input.mousePosition.y > (Screen.height - ScreenEdgeBorderWidth))
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(0, 0, MoveSpeed * num);
+                    _rtsCamera.AddToPosition(0, 0, MoveSpeed * num * distanceModifier);
                 }
                 else if (Input.mousePosition.y < ScreenEdgeBorderWidth)
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(0, 0, -1 * MoveSpeed * num);
+                    _rtsCamera.AddToPosition(0, 0, -1 * MoveSpeed * num * distanceModifier);
                 }
 
                 if (Input.mousePosition.x > (Screen.width - ScreenEdgeBorderWidth))
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(MoveSpeed * num, 0, 0);
+                    _rtsCamera.AddToPosition(MoveSpeed * num * distanceModifier, 0, 0);
                 }
                 else if (Input.mousePosition.x < ScreenEdgeBorderWidth)
                 {
                     hasMovement = true;
-                    _rtsCamera.AddToPosition(-1 * MoveSpeed * num, 0, 0);
+                    _rtsCamera.AddToPosition(-1 * MoveSpeed * num * distanceModifier, 0, 0);
                 }
 
                 if (hasMovement && _rtsCamera.IsFollowing && ScreenEdgeMoveBreaksFollow)


### PR DESCRIPTION
Fixed camera movement while typing.
Made camera movement and scroll-intervals dependent on camera distance.

Gives it an overall more natural and intuitive feel, 
especially when moving around zoomed all the way in, or zooming itself.
Getting the right spot for a nice, head-leveled screenshot seemed impossible,
and scrolling steps felt too far apart zoomed in, and unnessecarily close toghether zoomed out.

All values are trial and error until they felt right.
They're not perfect, but close enough for me.

Hope you like my tweaks :>